### PR TITLE
Fixed Includes for ESP Devices on Linux with PlatformIO

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2010 DFRobot Co.Ltd
+Copyright 2010 DFRobot Co.Ltd, additions copyright Sam Groveman, 2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 DFRobot_EnvironmentalSensor
 ===========================
 
+This has been modified to be compatible with ESP32 devices.
+
 * [中文版](./README_CN.md)
 
 The multifunctional environmental sensor(SEN0500/SEN0501) integrates the UV, illumination, atmospheric pressure and temperature and humidity detection functions into one. It features Gravity and Breakout interfaces, and supports UART and I2C data communication, which can be selected by the onboard switch. <br/>

--- a/src/DFRobot_EnvironmentalSensor.h
+++ b/src/DFRobot_EnvironmentalSensor.h
@@ -12,10 +12,10 @@
 #ifndef DFROBOT_MULTIFUNCTIONAL_ENVIRONMENTAL_SENSOR_H
 #define DFROBOT_MULTIFUNCTIONAL_ENVIRONMENTAL_SENSOR_H
 
+#pragma once
 #include "Arduino.h"
 #include "Wire.h"
 #include "DFRobot_RTU.h"
-#include "String.h"
 
 #if (defined ARDUINO_AVR_UNO) && (defined ESP8266)
 #include "SoftwareSerial.h"

--- a/src/DFRobot_EnvironmentalSensor.h
+++ b/src/DFRobot_EnvironmentalSensor.h
@@ -16,6 +16,9 @@
 #include "Arduino.h"
 #include "Wire.h"
 #include "DFRobot_RTU.h"
+#if !defined(ESP8266) && !defined(ESP32)
+#include "String.h"
+#endif
 
 #if (defined ARDUINO_AVR_UNO) && (defined ESP8266)
 #include "SoftwareSerial.h"


### PR DESCRIPTION
Compilation fails on Linux computers using PlatformIO targeting ESP32 or ESP8266 devices. The problem was the inclusion of `String.h`. The `String` class is defined in [`WString.h`](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/WString.h) and already included from [`Arduino.h`](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/Arduino.h#L295). `String.h` includes may also be unnecessary for other devices, but this wasn't tested.